### PR TITLE
Fix GitHub Actions CI failures and add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,50 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 1
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/acousticalc
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # acousticalc
 
 A TUI-based application for calculating room acoustics.
+
+## Build
+
+To build the application, run:
+
+```bash
+go build -o acousticalc ./cmd/acousticalc
+```
+
+## Usage
+
+After building, you can run the application with:
+
+```bash
+./acousticalc "2 + 3 * 4"
+```
+
+## Installation
+
+Download the latest release from the [GitHub Releases](https://github.com/dmisiuk/acousticalc/releases) page.
+
+## GitHub Actions
+
+This project uses GitHub Actions for CI/CD:
+
+- CI workflow: Runs on every push and pull request to test the application
+- Release workflow: Runs when a new tag is pushed to create a new release
+
+## Development
+
+To run tests:
+
+```bash
+go test ./...
+```
+
+To run tests with coverage:
+
+```bash
+go test -cover ./...
+```

--- a/cmd/acousticalc/main_integration_test.go
+++ b/cmd/acousticalc/main_integration_test.go
@@ -18,8 +18,8 @@ func getExecutablePath() (string, error) {
 	}
 
 	// Build the path to the executable
-	// Assuming the executable is in the project root
-	dir := filepath.Dir(filepath.Dir(filename)) // Go up two levels from cmd/acousticalc/
+	// The executable is in the same directory as the test file
+	dir := filepath.Dir(filename)
 	return filepath.Join(dir, "acousticalc"), nil
 }
 


### PR DESCRIPTION
## Summary
- Fix CLI integration test executable path that was causing CI failures
- Add comprehensive README with build instructions and usage examples
- Add GitHub Actions release workflow with GoReleaser configuration
- Enable automated releases on tag pushes

## Changes
- Fixed: CLI integration test executable path in `cmd/acousticalc/main_integration_test.go:23`
- Added: Build, usage, and development instructions to README.md
- Added: GitHub Actions release workflow (.github/workflows/release.yml)
- Added: GoReleaser configuration (.goreleaser.yml)

## Test plan
- [x] All tests pass locally (`go test ./...`)
- [x] CLI integration tests work correctly
- [x] GitHub Actions workflow should pass

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)